### PR TITLE
Added hooks() function

### DIFF
--- a/php-hooks.php
+++ b/php-hooks.php
@@ -562,3 +562,8 @@ if (!class_exists('Hooks')){
 global $hooks;
 $hooks = new Hooks();
 $hooks->do_action('After_Hooks_Setup',$hooks);
+
+function hooks() {
+	global $hooks;
+	return $hooks;
+}


### PR DESCRIPTION
I've added this at the end of the file:

``` php
function hooks() {
    global $hooks;
    return $hooks;
}
```

So instead of:

``` php
...my_custom_method_somewhere() {
   global $hooks;
   $hooks->do_action('my_custom_hook');
}
```

I can do just:

``` php
...my_custom_method_somewhere() {
   hooks()->do_action('my_custom_hook');
}
```

As well as, instead:

``` php
...blah() {
   global $hooks;
   $hooks->add_action('my_custom_hook', function() {
      echo 'blah';
   });
}
```

I can just do:

``` php
...blah() {
   hooks()->add_action('my_custom_hook', function() {
      echo 'blah';
   });
}
```
